### PR TITLE
Add content-wrapper class to sponsor page to allow scrolling

### DIFF
--- a/src/Sponsorship.elm
+++ b/src/Sponsorship.elm
@@ -15,7 +15,7 @@ type alias Tier =
 
 
 markup =
-    [ div [ Attr.class "sponsorship", css Styles.sponsorship.wrapper ] <|
+    [ div [ Attr.class "content-wrapper sponsorship", css Styles.sponsorship.wrapper ] <|
         [ escape
         , hero
         ]


### PR DESCRIPTION
Noticed the sponsor page wasn't scrolling. This PR adds the 'content-wrapper' class to the sponsor page to allow scrolling (like the main page).